### PR TITLE
Test JSON as Perl object, not string.

### DIFF
--- a/t/04_create_send_data.t
+++ b/t/04_create_send_data.t
@@ -22,9 +22,9 @@ subtest 'success' => sub {
     is $identifier, 0;
     is $expiry, 0;
     is $device_token, 'device_token';
-    is $json, $apns->json->encode({
+    is_deeply $apns->json->decode($json), {
         aps => { alert => 'メッセージ' },
-    });
+    };
 };
 
 subtest 'with extras' => sub {
@@ -38,9 +38,9 @@ subtest 'with extras' => sub {
     is $identifier, 12345;
     is $expiry, 56789;
     is $device_token, 'device_token';
-    is $json, $apns->json->encode({
+    is_deeply $apns->json->decode($json), {
         aps => { alert => 'メッセージ' },
-    });
+    };
 };
 
 subtest 'trimed' => sub {
@@ -54,9 +54,9 @@ subtest 'trimed' => sub {
     is $identifier, 12345;
     is $expiry, 56789;
     is $device_token, 'device_token';
-    is $json, $apns->json->encode({
+    is_deeply $apns->json->decode($json), {
         aps => { alert => 'メッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセ' },
-    });
+    };
 };
 
 subtest 'badge to numify' => sub {
@@ -70,9 +70,9 @@ subtest 'badge to numify' => sub {
     is $identifier, 12345;
     is $expiry, 56789;
     is $device_token, 'device_token';
-    is $json, $apns->json->encode({
+    is_deeply $apns->json->decode($json), {
         aps => { alert => 'メッセージ', badge => 100 },
-    });
+    };
 };
 
 subtest 'trimd alter.body' => sub {
@@ -86,14 +86,14 @@ subtest 'trimd alter.body' => sub {
     is $identifier, 12345;
     is $expiry, 56789;
     is $device_token, 'device_token';
-    is $json, $apns->json->encode({
+    is_deeply $apns->json->decode($json), {
         aps => {
             alert => {
                 body => 'メッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメッセージメ',
             },
             badge => 100,
         },
-    });
+    };
 };
 
 subtest 'command 0' => sub {
@@ -105,9 +105,9 @@ subtest 'command 0' => sub {
 
     is $command, 0;
     is $device_token, 'device_token';
-    is $json, $apns->json->encode({
+    is_deeply $apns->json->decode($json), {
         aps => { alert => 'メッセージ' },
-    });
+    };
 };
 
 done_testing;


### PR DESCRIPTION
If `$hashref` has multiple key-value pairs, `json->encode($hashref)`
returns unpredictable output from Perl 5.18, because of hash
randomization. So I think that it is not good test as string.

This fixes #1 issue
