### PR TITLE
Fix a POD typo, s/aps/apns if $sending_payload_data

### DIFF
--- a/lib/Net/APNs/Extended.pm
+++ b/lib/Net/APNs/Extended.pm
@@ -241,7 +241,7 @@ Sets write timeout.
 Send notification for APNs.
 
   $apns->send($device_token, {
-      apns => {
+      aps => {
           alert => "Hello, APNs!",
           badge => 1,
           sound => "default",

--- a/lib/Net/APNs/Extended/Base.pm
+++ b/lib/Net/APNs/Extended/Base.pm
@@ -225,7 +225,7 @@ sub DESTROY {
 sub _tmpfile {
     my $fh = File::Temp->new(
         TEMPLATE => "napnseXXXXXXXXXXX",
-        TEMPDIR  => 1,
+        TMPDIR   => 1,
         EXLOCK   => 0,
     );
     syswrite $fh, $_[0];


### PR DESCRIPTION
There is a small typo in the POD describing the data structure for sending a push notification.  This commit fixes that.