### PR TITLE
no error when response is ''

### DIFF
--- a/lib/Net/APNs/Extended.pm
+++ b/lib/Net/APNs/Extended.pm
@@ -90,7 +90,7 @@ sub send_multi {
 sub retrieve_error {
     my $self = shift;
     my $data = $self->_read;
-    return unless defined $data;
+    return unless $data;
 
     my ($command, $status, $identifier) = unpack 'C C L', $data;
     my $error = {


### PR DESCRIPTION
@xaicron 

When APNs close a connection, 
```Net::APNs::Extended::Base::_read``` method returns  ```"" ```, then ```retrieve_error``` returns ```{"command":null,"identifier":null,"status":null}``` now.
So I think we should ignore ```""``` at retrieve_error.

The supplement is below.
When APNs close a connection, 
```SSL_read``` returns ```0```, and 
```Net::SSLeay:::read``` returns ```0```, and
```Net::SSLeay:::ssl_read_all``` returns ```""```.

Related: https://github.com/xaicron/p5-Net-APNs-Extended/issues/6
